### PR TITLE
Remove slow Cloudfront distro creation loop

### DIFF
--- a/burlap/cloudfront.py
+++ b/burlap/cloudfront.py
@@ -35,16 +35,18 @@ class CloudfrontSatchel(Satchel):
             origin = boto.cloudfront.origin.S3Origin(origin_dns)
 
             distro = None
-            dists = conn.get_all_distributions()
-            for d in dists:
-                print('Checking existing Cloudfront distribution %s...' % d.get_distribution().config.origin.dns_name)
-                if origin_dns == d.get_distribution().config.origin.dns_name:
-                    print('Found existing distribution!')
-                    distro = d
-                    break
+            if self.verbose:
+                # Loop over all distributions to determine whether this one exists already.
+                dists = conn.get_all_distributions()
+                for d in dists:
+                    print('Checking existing Cloudfront distribution %s...' % d.get_distribution().config.origin.dns_name)
+                    if origin_dns == d.get_distribution().config.origin.dns_name:
+                        print('Found existing distribution!')
+                        distro = d
+                        break
 
-                # Necessary to avoid "Rate exceeded" errors.
-                time.sleep(0.4)
+                    # Necessary to avoid "Rate exceeded" errors.
+                    time.sleep(0.4)
 
             if not distro:
                 print('Creating new distribution from %s...' % origin)


### PR DESCRIPTION
Prevent Cloudfront from looping over all distributions when creating a new distribution in non-verbose mode.