### PR TITLE
Extend DjangoSatchel.install_sql() to support SQL string

### DIFF
--- a/burlap/dj.py
+++ b/burlap/dj.py
@@ -274,7 +274,7 @@ class DjangoSatchel(Satchel):
 
         name = database
         
-        assert fn ^ sql, "Either fn or sql is required."
+        assert bool(fn) ^ bool(sql), "Either fn or sql is required."
 
         r = self.local_renderer
         paths = glob.glob(r.format(r.env.install_sql_path_template))

--- a/burlap/dj.py
+++ b/burlap/dj.py
@@ -273,7 +273,7 @@ class DjangoSatchel(Satchel):
         site = site or ALL
 
         name = database
-        
+
         assert bool(fn) ^ bool(sql), "Either fn or sql is required."
 
         r = self.local_renderer
@@ -363,7 +363,7 @@ class DjangoSatchel(Satchel):
                     r.env.sql = sql
                     with self.settings(warn_only=not stop_on_error):
                         r.run('psql --user={db_user} --no-password --host={db_host} -d {db_name} --command="{sql}"')
-                else: 
+                else:
                     paths = list(get_paths('postgresql'))
                     run_paths(
                         paths=paths,


### PR DESCRIPTION
Not sure whether this is necessary/useful, but I tossed it together to fix the initial category migration on staging just now.