### PR TITLE
Add code satchel to apache dependencies

### DIFF
--- a/burlap/apache.py
+++ b/burlap/apache.py
@@ -673,7 +673,7 @@ class ApacheSatchel(ServiceSatchel):
         r = self.local_renderer
         r.sudo('[ -f {maintenance_path} ] && rm -f {maintenance_path} || true')
 
-    @task(precursors=['packager', 'user', 'hostname', 'ip'])
+    @task(precursors=['packager', 'user', 'hostname', 'ip', 'code'])
     def configure(self):
         self.configure_modevasive()
         self.configure_modsecurity()


### PR DESCRIPTION
If we're going to be using .wsgi files in the repo, those should be deployed before site configs get reloaded (this caused some problems today while debugging staging downtime)